### PR TITLE
fix(docker): bump Alpine base image to 3.22.2 for security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.1
+FROM alpine:3.22.2
 
 # Installs latest Chromium package.
 RUN apk upgrade --no-cache --available \


### PR DESCRIPTION
## Summary
Bump Alpine Linux base image from 3.22.1 to 3.22.2 to resolve security vulnerabilities in system packages.

## Changes
- Updated `Dockerfile` base image: `alpine:3.22.1` → `alpine:3.22.2`

## Security Vulnerabilities Resolved
This update pulls the latest Alpine packages with security fixes for:

| Severity | Package | CVE |
|----------|---------|-----|
| CRITICAL | mbedtls | CVE-2025-47917 |
| CRITICAL | cjson | CVE-2025-57052 |
| CRITICAL | sqlite | CVE-2025-6965 |
| HIGH | binutils | CVE-2025-5245 |
| MEDIUM | libpng | CVE-2025-64505 |
| MEDIUM | curl | CVE-2025-10148 |
| MEDIUM | openssl | CVE-2025-9231, CVE-2025-9232 |
| LOW | tiff | CVE-2025-9165 |

## Testing
- [x] Built image locally with `docker build --no-cache`
- [x] Pushed to test registry
- [x] Scanned with `gcloud artifacts docker images scan` - **0 vulnerabilities**

## Ticket
PLAT-484