### PR TITLE
fix(docker): bump Alpine base image to 3.22.3 for security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.2
+FROM alpine:3.22.3
 
 # Installs latest Chromium package.
 RUN apk upgrade --no-cache --available \


### PR DESCRIPTION
## Summary

Bumps the Alpine base image from `3.22.2` to `3.22.3` to resolve two CVEs identified in Artifact Registry (`vulnerability-fix-test/alpine-chrome`):

- **CVE-2025-66293** (HIGH, CVSS 7.1) — `libpng 1.6.51-r0` → fixed in `1.6.53-r0` (installed: `1.6.54-r0`)
- **CVE-2025-69277** — `libsodium 1.0.20-r0` → fixed in `1.0.20-r1`

Both packages are pulled in as transitive dependencies of `chromium-swiftshader`. The existing `apk upgrade --no-cache --available` step handles picking up the patched versions on rebuild.

## Test plan

- [ ] CI builds the base image successfully
- [ ] `with-node` and `with-puppeteer` variants build on top of the new base
- [ ] Scan rebuilt image in Artifact Registry confirms CVE-2025-66293 and CVE-2025-69277 are resolved